### PR TITLE
remove django import export lib

### DIFF
--- a/nakhll/settings.py
+++ b/nakhll/settings.py
@@ -76,7 +76,7 @@ THIRD_PARTY_APPS = [
     'django_extensions',
     'colorfield',
     'django_rename_app',
-    'import_export',
+    # 'import_export', # has conflict with django-excel-response in dependencies (openpyxl)
 ]
 
 NAKHLL_APPS = [

--- a/nakhll/urls.py
+++ b/nakhll/urls.py
@@ -3,13 +3,13 @@ from django.contrib import admin
 from django.urls import path, include
 from nakhll import settings
 from . import setup as nakhll_setup
-from reports.admin import reports_admin_site
+# from reports.admin import reports_admin_site
 nakhll_setup.seutp()
 
 
 view_urls = [
     path('logintowebsite/', admin.site.urls),
-    path('reportspanel/', reports_admin_site.urls),
+    # path('reportspanel/', reports_admin_site.urls),
     path('accounting/', include('accounting.urls', namespace='accounting')),
     path('torob/', include('torob_api.urls', namespace='torob')),
     path('goto/', include('url_redirector.urls', namespace='url_redirector')),

--- a/panel_admins/reports.py
+++ b/panel_admins/reports.py
@@ -1,21 +1,21 @@
-from django.contrib.admin import AdminSite
-
-
-class ReportsAdminSite(AdminSite):
-    site_header = "Panel for get reports"
-    site_title = "Nakhll reports panel"
-    index_title = "Welcome to Nakhll reports panel"
-
-    def has_permission(self, request):
-        """
-        Return True if the given HttpRequest has permission to view
-        *at least one* page in the admin site.
-        """
-        groups = request.user.groups.all()
-        if request.user.is_active and request.user.is_staff:
-            # if request.user.is_active and request.user.is_staff and 'reports' in [group.name for group in groups]:
-            return True
-        return False
-
-
-reports_admin_site = ReportsAdminSite(name='reports_admin')
+# from django.contrib.admin import AdminSite
+#
+#
+# class ReportsAdminSite(AdminSite):
+#     site_header = "Panel for get reports"
+#     site_title = "Nakhll reports panel"
+#     index_title = "Welcome to Nakhll reports panel"
+#
+#     def has_permission(self, request):
+#         """
+#         Return True if the given HttpRequest has permission to view
+#         *at least one* page in the admin site.
+#         """
+#         groups = request.user.groups.all()
+#         if request.user.is_active and request.user.is_staff:
+#             # if request.user.is_active and request.user.is_staff and 'reports' in [group.name for group in groups]:
+#             return True
+#         return False
+#
+#
+# reports_admin_site = ReportsAdminSite(name='reports_admin')

--- a/reports/admin.py
+++ b/reports/admin.py
@@ -1,65 +1,65 @@
 from django.contrib import admin
-from panel_admins.reports import reports_admin_site
+# from panel_admins.reports import reports_admin_site
 # Register your models here.
 from .models import InvoiceItemReport, InoviceProxy
-from import_export.admin import ExportActionMixin
-from import_export import resources
-from import_export.fields import Field
+# from import_export.admin import ExportActionMixin
+# from import_export import resources
+# from import_export.fields import Field
 
 
-class InvoiceItemReportResource(resources.ModelResource):
-    product_title = Field()
+# class InvoiceItemReportResource(resources.ModelResource):
+#     product_title = Field()
+#
+#     def dehydrate_product_title(self, InvoiceItemReport):
+#         return InvoiceItemReport.product.Title
+#
+#     class Meta:
+#         model = InvoiceItemReport
+#         exclude = ('product',)
+#
+#     def dehydrate_product_name(self, invoice_item_report):
+#         return invoice_item_report.product.Title
 
-    def dehydrate_product_title(self, InvoiceItemReport):
-        return InvoiceItemReport.product.Title
-
-    class Meta:
-        model = InvoiceItemReport
-        exclude = ('product',)
-
-    def dehydrate_product_name(self, invoice_item_report):
-        return invoice_item_report.product.Title
-
-
-@admin.register(InvoiceItemReport, site=reports_admin_site)
-class InvoiceItemReportAdmin(ExportActionMixin, admin.ModelAdmin):
-    list_display = ('id', 'invoice_number', 'invoice_status', 'product_name', 'product_shop')
-    list_filter = ('status',)
-    resource_class = InvoiceItemReportResource
-    ordering = ('-id',)
-
-    # product items
-    def product_name(self, obj):
-        return obj.product.Title
-
-    product_name.short_description = 'اسم محصول'
-
-    def product_shop(self, obj):
-        return obj.product.FK_Shop.Title
-
-    product_shop.short_description = 'فروشگاه'
-
-    # invoice items
-    def invoice_status(self, obj):
-        return obj.invoice.status
-
-    invoice_status.short_description = 'وضعیت فاکتور'
-
-    def invoice_number(self, obj):
-        return obj.invoice.id
-
-    invoice_number.short_description = 'شماره فاکتور'
-
-    def get_queryset(self, request):
-        qs = super(InvoiceItemReportAdmin, self).get_queryset(request)
-        qs = qs.filter(invoice__status=InoviceProxy.Statuses.COMPLETED)
-        return qs.select_related('invoice', 'product')
-
-    def has_add_permission(self, request):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return False
+#
+# @admin.register(InvoiceItemReport, site=reports_admin_site)
+# class InvoiceItemReportAdmin(admin.ModelAdmin):
+#     list_display = ('id', 'invoice_number', 'invoice_status', 'product_name', 'product_shop')
+#     list_filter = ('status',)
+#     resource_class = InvoiceItemReportResource
+#     ordering = ('-id',)
+#
+#     # product items
+#     def product_name(self, obj):
+#         return obj.product.Title
+#
+#     product_name.short_description = 'اسم محصول'
+#
+#     def product_shop(self, obj):
+#         return obj.product.FK_Shop.Title
+#
+#     product_shop.short_description = 'فروشگاه'
+#
+#     # invoice items
+#     def invoice_status(self, obj):
+#         return obj.invoice.status
+#
+#     invoice_status.short_description = 'وضعیت فاکتور'
+#
+#     def invoice_number(self, obj):
+#         return obj.invoice.id
+#
+#     invoice_number.short_description = 'شماره فاکتور'
+#
+#     def get_queryset(self, request):
+#         qs = super(InvoiceItemReportAdmin, self).get_queryset(request)
+#         qs = qs.filter(invoice__status=InoviceProxy.Statuses.COMPLETED)
+#         return qs.select_related('invoice', 'product')
+#
+#     def has_add_permission(self, request):
+#         return False
+#
+#     def has_delete_permission(self, request, obj=None):
+#         return False
+#
+#     def has_change_permission(self, request, obj=None):
+#         return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ django-excel-response==2.0.5
 django-extensions==3.1.3
 django-filter==2.4.0
 django-imagekit==4.0.2
-django-import-export==2.8.0
 django-ipware==2.1.0
 django-jalali==4.1.2
 django-mathfilters==1.0.0


### PR DESCRIPTION
we have a conflict in the version of openpyxl that use in two libraries.
1- Django import export lib -> user openpyxl==3.0.9
2- Django excel response lib -> use openpyxl=2.4.11

so we remove "Django import-export" to fix this bug. 
later we should check all libraries that are in requirements.txt.