### PR TITLE
unpublished products must be hidden from end user, only admins and shop manager can see it

### DIFF
--- a/nakhll/load_django_settings_for_unittest.py
+++ b/nakhll/load_django_settings_for_unittest.py
@@ -1,0 +1,5 @@
+import os
+from django import setup
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'nakhll.settings')
+setup()

--- a/nakhll_market/api.py
+++ b/nakhll_market/api.py
@@ -19,6 +19,7 @@ from rest_framework.decorators import action
 from django_filters import rest_framework as restframework_filters
 from logistic.models import ShopLogisticUnit
 from nakhll.utils import excel_response, get_dict
+from nakhll_market.exceptions import UnPublishedShop
 from nakhll_market.interface import DiscordAlertInterface, ProductChangeTypes
 from nakhll_market.models import (
     Alert,
@@ -447,8 +448,14 @@ class GetShopWithSlug(views.APIView):
 class GetShop(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
     permission_classes = [permissions.IsAuthenticatedOrReadOnly, ]
     serializer_class = ShopSerializer
-    queryset = Shop.objects.filter(Available=True, Publish=True)
+    queryset = Shop.objects.all()
     lookup_field = 'Slug'
+
+    def get_object(self):
+        shop = super().get_object()
+        if not shop.Publish:
+            raise UnPublishedShop()
+        return shop
 
 
 class GetShopList(viewsets.GenericViewSet, mixins.ListModelMixin):

--- a/nakhll_market/api.py
+++ b/nakhll_market/api.py
@@ -334,17 +334,22 @@ class ProductsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     ordering_fields = ('Title', 'Price', 'DiscountPrecentage', 'DateCreate',)
 
     def get_queryset(self):
-        res = Product.objects.select_related('FK_Shop').annotate(
-            is_available=Cast(Case(
-                When(Q(FK_Shop__Publish=True) & Q(FK_Shop__Available=True) &
-                     Q(Publish=True) & Q(Available=True) & Q(Inventory__gt=0),
-                     then=Value(True)),
-                default=Value(False)), output_field=BooleanField())
-        ).filter(
-            Q(Publish=True), ~Q(FK_Shop=None)).annotate(DiscountPrecentage=Case(
-                When(OldPrice__gt=0, then=(
-                    (F('OldPrice') - F('Price')) * 100 / F('OldPrice'))
-                ), default=0)).order_by('-is_available', '-category_id')
+        res = Product.objects.filter(Publish=True, FK_Shop__Publish=True).\
+            select_related('FK_Shop').annotate(
+            is_available=Cast(
+                Case(
+                    When(
+                        Q(Status__in=(1, 2, 3)) &
+                        Q(Inventory__gt=0),
+                        then=Value(True)),
+                    default=Value(False)),
+                output_field=BooleanField())).annotate(
+            DiscountPrecentage=Case(
+                When(
+                    OldPrice__gt=0,
+                    then=((F('OldPrice') - F('Price')) * 100 / F('OldPrice'))),
+                default=0)).order_by(
+            '-is_available', '-category_id')
         search_query = self.request.query_params.get('search', None)
         q_query = self.request.query_params.get('q', None)
         if search_query:

--- a/nakhll_market/exceptions.py
+++ b/nakhll_market/exceptions.py
@@ -1,0 +1,8 @@
+from django.utils.translation import gettext as _
+from rest_framework.exceptions import APIException
+
+
+class UnPublishedShop(APIException):
+    default_detail = _(
+        'فروشگاه به دلایلی قابل دسترس نمی باشد.')
+    status_code = 400

--- a/nakhll_market/exceptions.py
+++ b/nakhll_market/exceptions.py
@@ -2,7 +2,13 @@ from django.utils.translation import gettext as _
 from rest_framework.exceptions import APIException
 
 
-class UnPublishedShop(APIException):
+class UnPublishedShopException(APIException):
     default_detail = _(
         'فروشگاه به دلایلی قابل دسترس نمی باشد.')
+    status_code = 400
+
+
+class UnPublishedProductException(APIException):
+    default_detail = _(
+        'محصول به دلایلی قابل دسترس نمی باشد.')
     status_code = 400

--- a/nakhll_market/tests.py
+++ b/nakhll_market/tests.py
@@ -1,3 +1,102 @@
+from unicodedata import category
+from nakhll import load_django_settings_for_unittest
 from django.test import TestCase
-
+from rest_framework.test import APIClient
 # Create your tests here.
+from django.contrib.auth.models import User
+from nakhll_market.models import Product, Shop, Category
+
+
+class ShopDetailPageTestCase(TestCase):
+    def setUp(self) -> None:
+        self.url = '/api/v1/shop/{}/'
+        self.published_slug = 'a'
+        self.unpublished_slug = 'b'
+        user = User.objects.create_user(username='a')
+        shop = Shop.objects.create(
+            Title=self.published_slug,
+            Slug=self.published_slug,
+            FK_ShopManager=user,
+            Publish=True)
+        shop = Shop.objects.create(
+            Title=self.unpublished_slug,
+            Slug=self.unpublished_slug,
+            FK_ShopManager=user,
+            Publish=False)
+        self.client = APIClient()
+
+    def test_published_shop(self):
+        response = self.client.get(self.url.format(self.published_slug))
+        self.assertEqual(response.status_code, 200)
+
+    def test_unpublished_shop(self):
+        response = self.client.get(self.url.format(self.unpublished_slug))
+        self.assertEqual(response.status_code, 400)
+
+    def test_not_found_shop(self):
+        response = self.client.get(self.url.format('c'))
+        self.assertEqual(response.status_code, 404)
+
+
+class ProductDetailPageTestCase(TestCase):
+    def setUp(self) -> None:
+        self.url = '/api/v1/product-page/details/{}/'
+        user = User.objects.create_user(username='a')
+        category = Category.objects.create(name='a', slug='a')
+        Shop.objects.create(
+            Title='a',
+            Slug='a',
+            FK_ShopManager=user,
+            Publish=True)
+        Shop.objects.create(
+            Title='b',
+            Slug='b',
+            FK_ShopManager=user,
+            Publish=False)
+        Product.objects.create(
+            Title='a',
+            Slug='a',
+            FK_Shop=Shop.objects.get(Title='a'),
+            Publish=True,
+            Price=1000,
+            category=category,
+        )
+        Product.objects.create(
+            Title='b',
+            Slug='b',
+            FK_Shop=Shop.objects.get(Title='a'),
+            Publish=False,
+            Price=1000,
+            category=category,
+        )
+        Product.objects.create(
+            Title='c',
+            Slug='c',
+            FK_Shop=Shop.objects.get(Title='b'),
+            Publish=True,
+            Price=1000,
+            category=category,
+        )
+        Product.objects.create(
+            Title='d',
+            Slug='d',
+            FK_Shop=Shop.objects.get(Title='b'),
+            Publish=False,
+            Price=1000,
+            category=category,
+        )
+        self.client = APIClient()
+
+    def test_published_product(self):
+        response = self.client.get(self.url.format('a'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_unpublished_product_raise_error(self):
+        response = self.client.get(self.url.format('b'))
+        self.assertEqual(response.status_code, 400)
+        response = self.client.get(self.url.format('d'))
+        self.assertEqual(response.status_code, 400)
+
+    def test_unpublish_shop_raise_error(self):
+        response = self.client.get(self.url.format('c'))
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
product filter api is modified,
is_available flag is based on the inventory and status, and unpublished products are filtered
it seems `Available` flag is useless now.
